### PR TITLE
Ensure both Ollama models unload when switching to idle

### DIFF
--- a/core/mode_manager.py
+++ b/core/mode_manager.py
@@ -52,16 +52,25 @@ class ModeManager:
         """Unload everything"""
         logger.info("Switching to IDLE mode...")
 
-        # Unload Ollama
-        try:
-            requests.post(
-                f"{OLLAMA_API}/generate",
-                json={"model": OLLAMA_CHAT_MODEL, "keep_alive": 0},
-                timeout=5
-            )
-            logger.info("✓ Ollama unloaded")
-        except:
-            pass
+        # Unload Ollama models
+        for model_name in (OLLAMA_CHAT_MODEL, OLLAMA_VISION_MODEL):
+            try:
+                response = requests.post(
+                    f"{OLLAMA_API}/generate",
+                    json={"model": model_name, "keep_alive": 0},
+                    timeout=5
+                )
+                if response.status_code == 200:
+                    logger.info(f"✓ Ollama model '{model_name}' unloaded")
+                else:
+                    logger.warning(
+                        "⚠️ Ollama responded with status %s while unloading '%s': %s",
+                        response.status_code,
+                        model_name,
+                        response.text
+                    )
+            except requests.RequestException as exc:
+                logger.warning("⚠️ Failed to unload Ollama model '%s': %s", model_name, exc)
 
         # Clear CUDA cache
         if torch and torch.cuda.is_available():


### PR DESCRIPTION
## Summary
- update idle mode transition to unload both Ollama chat and vision models
- add per-model logging for unload successes and failures to aid troubleshooting

## Testing
- python - <<'PY'
import logging
from unittest.mock import patch, MagicMock

from core.mode_manager import ModeManager

class DummyVRAM:
    def get_vram_usage(self):
        return {"available": True, "used_gb": 0, "total_gb": 0, "percentage": 0}

class DummyComfy:
    def is_available(self):
        return True
    def get_status(self):
        return {"available": True}

logging.getLogger('core.mode_manager').setLevel(logging.INFO)

mm = ModeManager(DummyVRAM(), DummyComfy())

def fake_post(url, json, timeout):
    resp = MagicMock()
    resp.status_code = 200
    resp.text = "OK"
    return resp

with patch('core.mode_manager.requests.post', side_effect=fake_post) as mock_post:
    mm.switch_to_vision()
    mm.switch_to_idle()
    print('calls:', [call.kwargs['json'] for call in mock_post.call_args_list])
PY

------
https://chatgpt.com/codex/tasks/task_e_68dd5c85595c83288bfe91107874ddf0