### PR TITLE
Fix queue current job cleanup when clearing completed jobs

### DIFF
--- a/core/generation_queue.py
+++ b/core/generation_queue.py
@@ -171,22 +171,25 @@ class GenerationQueue:
             "paused": self.paused,
             "current_job": self._get_current_job_info()
         }
-
-    def _get_current_job_info(self) -> Optional[Dict]:
-        """Return information about the current job if it's valid."""
+        """Return information about the current job if it's valid. Does not modify state."""
         if not self.current_job:
             return None
 
         if self.current_job not in self.jobs:
-            self.current_job = None
             return None
+
         if self.current_job.status == JobStatus.PROCESSING:
             return self.current_job.to_dict()
 
-        # Job is still referenced but no longer processing; clear it.
-        self.current_job = None
+        # Job is still referenced but no longer processing.
         return None
 
+    def _cleanup_current_job_reference(self):
+        """Clear current_job if it is no longer valid."""
+        if not self.current_job:
+            return
+        if self.current_job not in self.jobs or self.current_job.status != JobStatus.PROCESSING:
+            self.current_job = None
     def get_queue_display(self) -> str:
         """Get formatted queue status for display"""
         status = self.get_queue_status()

--- a/core/generation_queue.py
+++ b/core/generation_queue.py
@@ -111,18 +111,27 @@ class GenerationQueue:
         return False
 
     def clear_completed(self):
-        """Remove completed, failed, and cancelled jobs"""
+        """Remove completed, failed, and cancelled jobs
+
+        Note: If current_job is removed during cleanup, we clear the reference.
+        This is safe even if a job is actively processing, as we only clear
+        the reference when the job is no longer in the queue or not processing.
+        """
         original_count = len(self.jobs)
         self.jobs = [job for job in self.jobs
                     if job.status not in [JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED]]
         removed = original_count - len(self.jobs)
 
-        if self.current_job and (
-            self.current_job.status != JobStatus.PROCESSING or
-            self.current_job not in self.jobs
-        ):
-            self.current_job = None
-            self.is_processing = False
+        # Clear stale current_job references after removing finished work
+        if self.current_job:
+            # If job is not processing, clear the reference
+            if self.current_job.status != JobStatus.PROCESSING:
+                self.current_job = None
+                self.is_processing = False
+            # If job was removed from the queue, clear the reference
+            elif self.current_job not in self.jobs:
+                self.current_job = None
+                self.is_processing = False
 
         if removed > 0:
             logger.info(f"Cleared {removed} finished jobs")

--- a/core/generation_queue.py
+++ b/core/generation_queue.py
@@ -116,6 +116,14 @@ class GenerationQueue:
         self.jobs = [job for job in self.jobs
                     if job.status not in [JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED]]
         removed = original_count - len(self.jobs)
+
+        if self.current_job and (
+            self.current_job.status != JobStatus.PROCESSING or
+            self.current_job not in self.jobs
+        ):
+            self.current_job = None
+            self.is_processing = False
+
         if removed > 0:
             logger.info(f"Cleared {removed} finished jobs")
 
@@ -152,8 +160,25 @@ class GenerationQueue:
             "completed": completed,
             "failed": failed,
             "paused": self.paused,
-            "current_job": self.current_job.to_dict() if self.current_job else None
+            "current_job": self._get_current_job_info()
         }
+
+    def _get_current_job_info(self) -> Optional[Dict]:
+        """Return information about the current job if it's valid."""
+        if not self.current_job:
+            return None
+
+        if self.current_job not in self.jobs:
+            if self.current_job.status != JobStatus.PROCESSING:
+                self.current_job = None
+            return None
+
+        if self.current_job.status == JobStatus.PROCESSING:
+            return self.current_job.to_dict()
+
+        # Job is still referenced but no longer processing; clear it.
+        self.current_job = None
+        return None
 
     def get_queue_display(self) -> str:
         """Get formatted queue status for display"""

--- a/core/generation_queue.py
+++ b/core/generation_queue.py
@@ -178,10 +178,8 @@ class GenerationQueue:
             return None
 
         if self.current_job not in self.jobs:
-            if self.current_job.status != JobStatus.PROCESSING:
-                self.current_job = None
+            self.current_job = None
             return None
-
         if self.current_job.status == JobStatus.PROCESSING:
             return self.current_job.to_dict()
 

--- a/test_phase25_completion.py
+++ b/test_phase25_completion.py
@@ -49,6 +49,7 @@ def test_generation_queue():
     next_job = queue.get_next_job()
     assert next_job is not None
     assert next_job.status == JobStatus.PENDING
+    queue.current_job = next_job
     print(f"✓ Got next job: {next_job.prompt[:20]}...")
 
     # Test 4: Update job status
@@ -88,6 +89,9 @@ def test_generation_queue():
     queue.clear_completed()
     # Should have removed completed and cancelled jobs
     assert len(queue.jobs) < original_count
+    assert queue.current_job is None, "Current job reference should be cleared"
+    status_after_clear = queue.get_queue_status()
+    assert status_after_clear["current_job"] is None, "Queue status should not expose stale current job"
     print(f"✓ Cleared completed/cancelled jobs. {len(queue.jobs)} remaining (was {original_count})")
 
     # Test 8: Estimate time remaining


### PR DESCRIPTION
## Summary
- clear stale current job references when removing finished work from the generation queue
- guard queue status reporting against removed or completed current jobs
- extend generation queue tests to verify current job cleanup and status reporting

## Testing
- python test_phase25_completion.py

------
https://chatgpt.com/codex/tasks/task_e_68dd6156a6148328adc70cefb5ea3e84