### PR TITLE
Improve ComfyUI availability error handling

### DIFF
--- a/comfyui_api.py
+++ b/comfyui_api.py
@@ -32,7 +32,7 @@ class ComfyUIBridge:
             response = requests.get(f"{self.api_url}/system_stats", timeout=2)
             return response.status_code == 200
         except requests.RequestException as exc:
-            logger.exception("Error checking ComfyUI availability: %s", exc)
+            logger.warning("ComfyUI not available: %s", exc)
         return False
 
     def get_status(self):

--- a/comfyui_api.py
+++ b/comfyui_api.py
@@ -31,9 +31,10 @@ class ComfyUIBridge:
         try:
             response = requests.get(f"{self.api_url}/system_stats", timeout=2)
             return response.status_code == 200
-        except:
-            return False
-    
+        except requests.RequestException as exc:
+            logger.exception("Error checking ComfyUI availability: %s", exc)
+        return False
+
     def get_status(self):
         """Get detailed status of ComfyUI"""
         try:
@@ -45,8 +46,10 @@ class ComfyUIBridge:
                     "vram_used": stats.get("system", {}).get("vram_used_gb", "Unknown"),
                     "vram_total": stats.get("system", {}).get("vram_total_gb", "Unknown")
                 }
-        except:
-            pass
+        except requests.RequestException as exc:
+            logger.exception("Error getting ComfyUI status: %s", exc)
+        except ValueError as exc:
+            logger.exception("Invalid JSON from ComfyUI status response: %s", exc)
         return {"available": False}
     
     def load_workflow(self):

--- a/comfyui_api.py
+++ b/comfyui_api.py
@@ -49,7 +49,7 @@ class ComfyUIBridge:
         except requests.RequestException as exc:
             logger.exception("Error getting ComfyUI status: %s", exc)
         except ValueError as exc:
-            logger.exception("Invalid JSON from ComfyUI status response: %s", exc)
+            logger.exception("Invalid JSON from ComfyUI status response")
         return {"available": False}
     
     def load_workflow(self):


### PR DESCRIPTION
## Summary
- handle ComfyUI availability checks by catching `requests.RequestException` explicitly and logging errors
- log request and JSON parsing failures in `get_status` before returning an unavailable response

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd616d5f088328b5d522d91de8ce48