### PR TITLE
Add CI workflows for tests and docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,32 @@
+name: Documentation
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/**'
+      - '*.md'
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+
+jobs:
+  check-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Check for broken links
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        config-file: '.github/workflows/mlc_config.json'
+
+    - name: Validate documentation structure
+      run: |
+        echo "Checking documentation files..."
+        test -f README.md
+        test -f CONTRIBUTING.md
+        test -f CLAUDE.md
+        test -f docs/TYPING.md
+        echo "✅ All required documentation files exist"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main, dev ]
+  pull_request:
+    branches: [ main, dev ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
+
+    - name: Run linting
+      run: |
+        make lint
+
+    - name: Run type checking
+      run: |
+        make type-check
+      continue-on-error: true  # Type checking is optional for now
+
+    - name: Run tests
+      run: |
+        python test_new_features.py
+        python test_workflow_manager.py
+        python test_comprehensive.py


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to lint, type-check, and test the project on Python 3.10–3.12
- add a documentation workflow to validate docs updates and run markdown link checking

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd7f5102ec8328b60aa47b9ae0dea3