### PR TITLE
Handle multi-line VRAM monitor output

### DIFF
--- a/core/vram_monitor.py
+++ b/core/vram_monitor.py
@@ -69,7 +69,7 @@ class VRAMMonitor:
 
                     used_gb = used / 1024
                     total_gb = total / 1024
-                    percentage = (used / total) * 100 if total else 0
+                    percentage = (used / total) * 100
 
                     self.cached_vram = {
                         "used_gb": round(used_gb, 1),

--- a/core/vram_monitor.py
+++ b/core/vram_monitor.py
@@ -50,19 +50,35 @@ class VRAMMonitor:
             )
 
             if result.returncode == 0:
-                used, total = map(int, result.stdout.strip().split(","))
-                used_gb = used / 1024
-                total_gb = total / 1024
-                percentage = (used / total) * 100
+                lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+                for line in lines:
+                    parts = [part.strip() for part in line.split(",")]
+                    if len(parts) < 2:
+                        continue
 
-                self.cached_vram = {
-                    "used_gb": round(used_gb, 1),
-                    "total_gb": round(total_gb, 1),
-                    "percentage": round(percentage, 1),
-                    "available": True,
-                }
-                self.last_check = current_time
-                return self.cached_vram
+                    try:
+                        used = int(parts[0])
+                        total = int(parts[1])
+                    except ValueError:
+                        logger.debug("Unable to parse VRAM usage from line: %s", line)
+                        continue
+
+                    if total <= 0:
+                        logger.debug("Ignoring VRAM usage entry with non-positive total: %s", line)
+                        continue
+
+                    used_gb = used / 1024
+                    total_gb = total / 1024
+                    percentage = (used / total) * 100 if total else 0
+
+                    self.cached_vram = {
+                        "used_gb": round(used_gb, 1),
+                        "total_gb": round(total_gb, 1),
+                        "percentage": round(percentage, 1),
+                        "available": True,
+                    }
+                    self.last_check = current_time
+                    return self.cached_vram
         except Exception as e:
             logger.debug(f"VRAM check failed: {e}")
 

--- a/test_vram_monitor.py
+++ b/test_vram_monitor.py
@@ -1,0 +1,47 @@
+import sys
+import types
+
+import pytest
+
+dotenv_stub = types.ModuleType("dotenv")
+dotenv_stub.load_dotenv = lambda *args, **kwargs: None
+sys.modules.setdefault("dotenv", dotenv_stub)
+
+from core.vram_monitor import VRAMMonitor
+
+
+class DummyCompletedProcess:
+    def __init__(self, stdout: str, returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+def test_get_vram_usage_handles_multi_line_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monitor = VRAMMonitor()
+
+    def fake_run(*args, **kwargs):
+        return DummyCompletedProcess("500,1000\n600,1200\n")
+
+    monkeypatch.setattr("core.vram_monitor.subprocess.run", fake_run)
+
+    result = monitor.get_vram_usage()
+
+    assert result == {
+        "used_gb": pytest.approx(round(500 / 1024, 1)),
+        "total_gb": pytest.approx(round(1000 / 1024, 1)),
+        "percentage": pytest.approx(round((500 / 1000) * 100, 1)),
+        "available": True,
+    }
+
+
+def test_get_vram_usage_returns_unavailable_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monitor = VRAMMonitor()
+
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError("nvidia-smi not found")
+
+    monkeypatch.setattr("core.vram_monitor.subprocess.run", fake_run)
+
+    result = monitor.get_vram_usage()
+
+    assert result == {"used_gb": 0, "total_gb": 16, "percentage": 0, "available": False}


### PR DESCRIPTION
## Summary
- parse `nvidia-smi` output line-by-line to safely cache VRAM data from the first valid record
- preserve failure fallback behavior and add targeted unit coverage for multi-line command output and outright command failure

## Testing
- pytest test_vram_monitor.py

------
https://chatgpt.com/codex/tasks/task_e_68dd890d67ac8328947a3e66b32330a0