### PR TITLE
Fix Ollama tags URL handling and add regression tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ import logging
 import random
 import time
 from datetime import datetime
+from urllib.parse import urljoin
 
 import gradio as gr
 import requests
@@ -65,14 +66,22 @@ mode_manager = ModeManager(vram_monitor, comfy)
 # ============================================================================
 
 
+def _build_ollama_tags_url(base_url: str) -> str:
+    """Construct the Ollama tags endpoint from the configured API URL."""
+    trimmed = base_url.rstrip("/")
+    if trimmed.endswith("/api"):
+        trimmed = trimmed[:-4]
+    return urljoin(trimmed.rstrip("/") + "/", "api/tags")
+
+
 def get_available_models():
     """Get list of Ollama models"""
     try:
-        response = requests.get(f"{OLLAMA_API.replace('/api', '')}/api/tags")
+        response = requests.get(_build_ollama_tags_url(OLLAMA_API))
         if response.status_code == 200:
             models = response.json().get("models", [])
             return [model["name"] for model in models]
-    except:
+    except Exception:
         pass
     return [OLLAMA_CHAT_MODEL, "mistral:7b", "mistral-small3.2:latest"]
 

--- a/app.py
+++ b/app.py
@@ -71,7 +71,7 @@ def _build_ollama_tags_url(base_url: str) -> str:
     trimmed = base_url.rstrip("/")
     if trimmed.endswith("/api"):
         trimmed = trimmed[:-4]
-    return urljoin(trimmed.rstrip("/") + "/", "api/tags")
+    return urljoin(trimmed + "/", "api/tags")
 
 
 def get_available_models():

--- a/test_app_models.py
+++ b/test_app_models.py
@@ -1,0 +1,47 @@
+"""Tests for Ollama model discovery helpers."""
+
+import types
+
+import pytest
+import requests
+
+import app
+
+
+def test_get_available_models_builds_tags_url(monkeypatch):
+    """Ensure the tags endpoint is built without clobbering '/api' elsewhere."""
+
+    captured = {}
+
+    def fake_get(url, *args, **kwargs):
+        captured["url"] = url
+        response = types.SimpleNamespace()
+        response.status_code = 200
+        response.json = lambda: {"models": [{"name": "llama3"}, {"name": "mistral"}]}
+        return response
+
+    monkeypatch.setattr(app, "OLLAMA_API", "http://example.com/some/api/path/api")
+    monkeypatch.setattr(app.requests, "get", fake_get)
+
+    models = app.get_available_models()
+
+    assert (
+        captured["url"]
+        == "http://example.com/some/api/path/api/tags"
+    )
+    assert models == ["llama3", "mistral"]
+
+
+def test_get_available_models_returns_fallback_on_failure(monkeypatch):
+    """Keep the existing fallback list when the tags request fails."""
+
+    monkeypatch.setattr(app, "OLLAMA_API", "http://example.com/api")
+    monkeypatch.setattr(app.requests, "get", lambda *args, **kwargs: (_ for _ in ()).throw(requests.RequestException()))
+
+    models = app.get_available_models()
+
+    assert models == [
+        app.OLLAMA_CHAT_MODEL,
+        "mistral:7b",
+        "mistral-small3.2:latest",
+    ]


### PR DESCRIPTION
## Summary
- build the Ollama tags endpoint using a helper that only trims a trailing `/api`
- keep the existing fallback behaviour when the tags request fails
- add pytest coverage to verify URL construction and fallback semantics

## Testing
- pytest test_app_models.py

------
https://chatgpt.com/codex/tasks/task_e_68dd89288848832892e637bdf5c5d8e1