### PR TITLE
Improve prompt import reporting

### DIFF
--- a/core/prompt_history.py
+++ b/core/prompt_history.py
@@ -135,20 +135,55 @@ class PromptHistory:
                 data = json.load(f)
                 imported = data.get("prompts", [])
 
+                original_len = len(self.prompts)
+                existing_prompts = {
+                    entry.get("prompt") for entry in self.prompts if entry.get("prompt")
+                }
+                duplicate_count = 0
+                invalid_count = 0
+
                 # Merge with existing, avoiding duplicates
                 for entry in imported:
                     prompt_text = entry.get("prompt", "")
-                    if prompt_text:
-                        # Check if already exists
-                        exists = any(p["prompt"] == prompt_text for p in self.prompts)
-                        if not exists:
-                            self.prompts.append(entry)
+                    if not prompt_text:
+                        invalid_count += 1
+                        continue
 
-                # Limit size
+                    if prompt_text in existing_prompts:
+                        duplicate_count += 1
+                        continue
+
+                    self.prompts.append(entry)
+                    existing_prompts.add(prompt_text)
+
+                # Limit size and track trimming
+                trimmed_count = 0
                 if len(self.prompts) > self.max_history:
+                    trimmed_count = len(self.prompts) - self.max_history
                     self.prompts = self.prompts[: self.max_history]
 
-                self.save_to_file()
-                return f"✅ Imported {len(imported)} prompts"
+                added_count = max(0, len(self.prompts) - original_len)
+
+                if added_count > 0 or trimmed_count > 0:
+                    self.save_to_file()
+
+                prompt_word = "prompt" if added_count == 1 else "prompts"
+                message = f"✅ Imported {added_count} {prompt_word}"
+
+                details = []
+                if duplicate_count:
+                    duplicate_word = "duplicate" if duplicate_count == 1 else "duplicates"
+                    details.append(f"{duplicate_count} {duplicate_word} skipped")
+                if invalid_count:
+                    invalid_word = "entry" if invalid_count == 1 else "entries"
+                    details.append(f"{invalid_count} invalid {invalid_word} ignored")
+                if trimmed_count:
+                    trimmed_word = "prompt" if trimmed_count == 1 else "prompts"
+                    details.append(f"{trimmed_count} {trimmed_word} trimmed by history limit")
+
+                if details:
+                    message += f" ({', '.join(details)})"
+
+                return message
         except Exception as e:
             return f"❌ Import failed: {e}"

--- a/core/prompt_history.py
+++ b/core/prompt_history.py
@@ -164,7 +164,7 @@ class PromptHistory:
 
                 added_count = max(0, len(self.prompts) - original_len)
 
-                if added_count > 0 or trimmed_count > 0:
+                if added_count > 0 or duplicate_count > 0 or invalid_count > 0 or trimmed_count > 0:
                     self.save_to_file()
 
                 prompt_word = "prompt" if added_count == 1 else "prompts"

--- a/test_new_features.py
+++ b/test_new_features.py
@@ -105,3 +105,35 @@ def test_prompt_history_persists_to_disk(tmp_path):
     assert len(reloaded_prompts) == 1
     assert reloaded_prompts[0]["prompt"] == prompt
     assert reloaded_prompts[0]["settings"] == settings
+
+
+def test_prompt_history_import_reports_actual_added(tmp_path):
+    history = create_history(tmp_path)
+
+    existing_prompt = "Atmospheric concept art of a misty forest temple at dawn"
+    history.add_prompt(existing_prompt)
+
+    duplicate_prompt = "Highly detailed digital painting of a dragon soaring above mountains"
+
+    import_data = {
+        "prompts": [
+            {"prompt": existing_prompt, "timestamp": "2024-01-01T00:00:00"},
+            {"prompt": duplicate_prompt, "timestamp": "2024-01-02T00:00:00"},
+            {"prompt": duplicate_prompt, "timestamp": "2024-01-03T00:00:00"},
+        ]
+    }
+
+    import_file = tmp_path / "import_prompts.json"
+    import_file.write_text(json.dumps(import_data), encoding="utf-8")
+
+    message = history.import_prompts(str(import_file))
+
+    assert "✅ Imported 1 prompt" in message
+    assert "2 duplicates skipped" in message
+
+    # Ensure the history reflects the actual number of new prompts reported
+    recent_prompts = history.get_recent_prompts(10)
+    imported_prompts = [entry["prompt"] for entry in recent_prompts]
+
+    assert duplicate_prompt in imported_prompts
+    assert imported_prompts.count(duplicate_prompt) == 1


### PR DESCRIPTION
## Summary
- track the number of prompts actually added during imports and report skipped duplicates/invalid entries
- add test coverage to ensure importing duplicate prompts reports the correct counts

## Testing
- `pytest test_new_features.py::test_prompt_history_import_reports_actual_added`


------
https://chatgpt.com/codex/tasks/task_e_68dd893902688328ab71874e00ddff24