### PR TITLE
Handle configurable logging directory

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ All settings in one place
 
 import logging
 import os
+from pathlib import Path
 
 from dotenv import load_dotenv
 
@@ -16,10 +17,21 @@ load_dotenv()
 # ============================================================================
 
 # Configure logging
+_default_log_dir = Path(__file__).resolve().parent / "data" / "logs"
+LOG_DIR = Path(os.getenv("LOG_DIR", _default_log_dir))
+
+log_handlers = [logging.StreamHandler()]
+
+try:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    log_handlers.append(logging.FileHandler(LOG_DIR / "ai_image_chat.log"))
+except OSError:
+    log_handlers.append(logging.NullHandler())
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    handlers=[logging.FileHandler("data/logs/ai_image_chat.log"), logging.StreamHandler()],
+    handlers=log_handlers,
 )
 
 # Set log level from environment variable if provided

--- a/tests/test_config_logging.py
+++ b/tests/test_config_logging.py
@@ -1,0 +1,15 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def test_config_creates_missing_log_dir(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv("LOG_DIR", str(log_dir))
+    sys.modules.pop("config", None)
+
+    config = importlib.import_module("config")
+
+    assert isinstance(config.LOG_DIR, Path)
+    assert config.LOG_DIR == log_dir
+    assert log_dir.exists()


### PR DESCRIPTION
## Summary
- create the logging directory from a configurable LOG_DIR path before configuring logging
- fall back to a NullHandler when the log directory cannot be created
- add a regression test that ensures config imports cleanly when the log directory does not yet exist

## Testing
- pytest -q *(fails: test_auto_switch.py::test_auto_mode_switching – requires Ollama service)*

------
https://chatgpt.com/codex/tasks/task_e_68e0807bf8888328894c93f3bbbc0fe0