### PR TITLE
Normalize workflow category comparisons

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,7 +67,7 @@ if not workflow_manager.get_current_workflow() and workflow_manager.get_workflow
     # Try to find a text2img workflow first
     text2img_workflow = None
     for workflow_id, workflow in workflow_manager.workflows.items():
-        if workflow.metadata.category == "text2img":
+        if workflow.metadata.matches_category("text2img"):
             text2img_workflow = workflow_id
             break
 
@@ -300,16 +300,22 @@ def generate_image(
     current_workflow = workflow_manager.get_current_workflow()
 
     # If current workflow doesn't match required category, find the right one
-    if not current_workflow or current_workflow.metadata.category != required_category:
+    if (
+        not current_workflow
+        or not current_workflow.metadata.matches_category(required_category)
+    ):
         logger.info(f"Searching for {required_category} workflow...")
         for workflow_id, workflow in workflow_manager.workflows.items():
-            if workflow.metadata.category == required_category:
+            if workflow.metadata.matches_category(required_category):
                 workflow_manager.set_current_workflow(workflow_id)
                 current_workflow = workflow
                 logger.info(f"Auto-selected {required_category} workflow: {workflow.metadata.name}")
                 break
 
-        if not current_workflow or current_workflow.metadata.category != required_category:
+        if (
+            not current_workflow
+            or not current_workflow.metadata.matches_category(required_category)
+        ):
             return None, f"❌ No {required_category} workflow available. Please add one to workflows/{required_category}/", None, None
 
     # Load workflow data into ComfyUI bridge (reload every time)

--- a/core/workflow_manager.py
+++ b/core/workflow_manager.py
@@ -18,6 +18,14 @@ logger = logging.getLogger(__name__)
 class WorkflowMetadata:
     """Metadata for a workflow"""
 
+    _CATEGORY_ALIASES = {
+        "text2image": "text2img",
+        "txt2image": "text2img",
+        "txt2img": "text2img",
+        "image2image": "img2img",
+        "image2img": "img2img",
+    }
+
     def __init__(
         self,
         name: str,
@@ -35,6 +43,26 @@ class WorkflowMetadata:
         self.author = author
         self.created_at = created_at or datetime.now().isoformat()
         self.modified_at = modified_at or datetime.now().isoformat()
+
+    @staticmethod
+    def normalize_category_slug(category: str | None) -> str:
+        """Normalize a category name into a comparable slug."""
+
+        if not category:
+            return ""
+
+        cleaned = "".join(ch for ch in category.lower() if ch.isalnum())
+        return WorkflowMetadata._CATEGORY_ALIASES.get(cleaned, cleaned)
+
+    def category_slug(self) -> str:
+        """Return the normalized slug for this workflow's category."""
+
+        return self.normalize_category_slug(self.category)
+
+    def matches_category(self, category: str) -> bool:
+        """Check if this metadata matches the provided category label or slug."""
+
+        return self.category_slug() == self.normalize_category_slug(category)
 
     def to_dict(self) -> dict:
         """Convert to dictionary"""
@@ -243,7 +271,12 @@ class WorkflowManager:
 
     def get_workflows_by_category(self, category: str) -> list[Workflow]:
         """Get all workflows in a category"""
-        return [wf for wf in self.workflows.values() if wf.metadata.category == category]
+
+        return [
+            wf
+            for wf in self.workflows.values()
+            if wf.metadata.matches_category(category)
+        ]
 
     def get_all_categories(self) -> list[str]:
         """Get list of all categories"""

--- a/core/workflow_manager.py
+++ b/core/workflow_manager.py
@@ -51,7 +51,7 @@ class WorkflowMetadata:
         if not category:
             return ""
 
-        cleaned = "".join(ch for ch in category.lower() if ch.isalnum())
+        cleaned = "".join(ch for ch in category.lower() if ch.isalnum() or ch in "_-")
         return WorkflowMetadata._CATEGORY_ALIASES.get(cleaned, cleaned)
 
     def category_slug(self) -> str:

--- a/tests/test_workflow_manager.py
+++ b/tests/test_workflow_manager.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 import pytest
 
-from core import WorkflowManager
+import app
+from core import Mode, WorkflowManager
 
 
 @pytest.fixture
@@ -64,3 +65,46 @@ def test_workflow_manager_delete_removes_files(populated_workflows_dir: Path) ->
     assert not workflow_path.exists()
     assert not metadata_path.exists()
     assert manager.get_workflow_count() == 1
+
+
+def test_generate_image_accepts_text2image_category(
+    populated_workflows_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Workflows with title case categories should match slug comparisons."""
+
+    manager = WorkflowManager(str(populated_workflows_dir))
+    manager.current_workflow_name = None
+
+    monkeypatch.setattr(app, "workflow_manager", manager)
+    monkeypatch.setattr(app.mode_manager, "get_mode", lambda: Mode.GENERATE)
+    monkeypatch.setattr(app.comfy, "load_workflow_from_data", lambda data: True)
+    monkeypatch.setattr(app.gallery, "add_image", lambda *_, **__: None)
+    monkeypatch.setattr(app.session_stats, "add_generation", lambda *_: None)
+    monkeypatch.setattr(app.session_stats, "get_stats_display", lambda: "stats")
+    monkeypatch.setattr(app.seed_manager, "add_seed", lambda *_: None)
+    monkeypatch.setattr(app.prompt_history, "add_prompt", lambda *_, **__: None)
+
+    def fake_get_seed(seed):
+        return 42
+
+    monkeypatch.setattr(app.seed_manager, "get_seed_for_generation", fake_get_seed)
+
+    def fake_generate_image(**kwargs):
+        return "image-bytes", "success", kwargs["seed"]
+
+    monkeypatch.setattr(app.comfy, "generate_image", fake_generate_image)
+
+    image, status, actual_seed, _ = app.generate_image(
+        prompt_text="Prompt long enough",
+        steps=10,
+        width=768,
+        height=768,
+        seed_value="",
+    )
+
+    assert image == "image-bytes"
+    assert "No text2img workflow available" not in status
+    assert actual_seed == 42
+    current = manager.get_current_workflow()
+    assert current is not None
+    assert current.metadata.matches_category("text2img")


### PR DESCRIPTION
## Summary
- normalize workflow metadata categories with slug helpers to support different naming conventions
- update workflow selection logic to rely on normalized categories and cover slug comparisons in tests
- add regression coverage ensuring Text2Image metadata loads correctly for image generation

## Testing
- pytest -o addopts="" tests/test_workflow_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e0859c14d8832891be00d99b2669e2