### PR TITLE
Handle duplicate workflow filenames via relative keys

### DIFF
--- a/core/workflow_manager.py
+++ b/core/workflow_manager.py
@@ -397,7 +397,7 @@ class WorkflowManager:
             if json_file.exists():
                 json_file.unlink()
 
-            meta_file = json_file.with_name(f"{json_file.stem}_meta.json")
+            meta_file = workflow.filepath.with_name(f"{workflow.filepath.stem}_meta.json")
             if meta_file.exists():
                 meta_file.unlink()
 

--- a/core/workflow_manager.py
+++ b/core/workflow_manager.py
@@ -210,7 +210,9 @@ class WorkflowManager:
         try:
             relative_path = filepath.relative_to(self.workflows_dir)
         except ValueError:
-            relative_path = filepath
+            raise WorkflowLoadError(
+                f"Workflow file '{filepath}' is outside the workflows directory '{self.workflows_dir}'."
+            )
 
         key = relative_path.as_posix()
         workflow = Workflow(key, filepath, workflow_data, metadata)

--- a/core/workflow_manager.py
+++ b/core/workflow_manager.py
@@ -93,8 +93,16 @@ class WorkflowMetadata:
 class Workflow:
     """Represents a ComfyUI workflow with metadata"""
 
-    def __init__(self, filename: str, workflow_data: dict, metadata: WorkflowMetadata):
-        self.filename = filename
+    def __init__(
+        self,
+        key: str,
+        filepath: Path,
+        workflow_data: dict,
+        metadata: WorkflowMetadata,
+    ):
+        self.key = key
+        self.filepath = filepath
+        self.filename = filepath.name
         self.workflow_data = workflow_data
         self.metadata = metadata
 
@@ -111,7 +119,11 @@ class Workflow:
 
     def to_dict(self) -> dict:
         """Convert to dictionary for storage"""
-        return {"filename": self.filename, "metadata": self.metadata.to_dict()}
+        return {
+            "filename": self.filename,
+            "path": self.key,
+            "metadata": self.metadata.to_dict(),
+        }
 
 
 class WorkflowManager:
@@ -119,8 +131,8 @@ class WorkflowManager:
 
     def __init__(self, workflows_dir: str = "./workflows"):
         self.workflows_dir = Path(workflows_dir)
-        self.workflows: dict[str, Workflow] = {}  # filename -> Workflow
-        self.current_workflow_name: str | None = None
+        self.workflows: dict[str, Workflow] = {}  # key -> Workflow
+        self.current_workflow_name: str | None = None  # Stores workflow key
 
         # Create workflows directory if it doesn't exist
         self.workflows_dir.mkdir(exist_ok=True)
@@ -195,11 +207,54 @@ class WorkflowManager:
                 category=self._infer_category(filepath),
             )
 
-        filename = filepath.name
-        workflow = Workflow(filename, workflow_data, metadata)
-        self.workflows[filename] = workflow
+        try:
+            relative_path = filepath.relative_to(self.workflows_dir)
+        except ValueError:
+            relative_path = filepath
+
+        key = relative_path.as_posix()
+        workflow = Workflow(key, filepath, workflow_data, metadata)
+        self.workflows[key] = workflow
 
         logger.info(f"✓ Loaded workflow: {workflow.metadata.name}")
+
+    def _normalize_identifier(self, identifier: str) -> str:
+        """Normalize user provided identifiers for lookup."""
+
+        identifier = identifier.replace("\\", "/")
+        path = Path(identifier)
+        if path.is_absolute():
+            try:
+                return path.relative_to(self.workflows_dir).as_posix()
+            except ValueError:
+                return path.as_posix()
+        return path.as_posix()
+
+    def _resolve_key(self, identifier: str) -> str | None:
+        """Resolve a workflow identifier to the stored key."""
+
+        normalized = self._normalize_identifier(identifier)
+
+        if normalized in self.workflows:
+            return normalized
+
+        # Allow lookup by simple filename when unambiguous
+        matches = [
+            key for key in self.workflows if Path(key).name == Path(normalized).name
+        ]
+
+        if len(matches) == 1:
+            return matches[0]
+
+        if len(matches) > 1:
+            logger.error(
+                "Ambiguous workflow identifier '%s'. Provide a relative path.",
+                identifier,
+            )
+        else:
+            logger.error("Workflow not found: %s", identifier)
+
+        return None
 
     def _infer_category(self, filepath: Path) -> str:
         """Infer category from file path"""
@@ -251,8 +306,12 @@ class WorkflowManager:
             return False
 
     def get_workflow(self, filename: str) -> Workflow | None:
-        """Get workflow by filename"""
-        return self.workflows.get(filename)
+        """Get workflow by identifier"""
+
+        key = self._resolve_key(filename)
+        if key is None:
+            return None
+        return self.workflows.get(key)
 
     def get_current_workflow(self) -> Workflow | None:
         """Get currently selected workflow"""
@@ -262,12 +321,16 @@ class WorkflowManager:
 
     def set_current_workflow(self, filename: str) -> bool:
         """Set current workflow"""
-        if filename in self.workflows:
-            self.current_workflow_name = filename
-            logger.info(f"✓ Switched to workflow: {self.workflows[filename].metadata.name}")
-            return True
-        logger.error(f"Workflow not found: {filename}")
-        return False
+        key = self._resolve_key(filename)
+        if key is None:
+            return False
+
+        self.current_workflow_name = key
+        logger.info(
+            "✓ Switched to workflow: %s",
+            self.workflows[key].metadata.name,
+        )
+        return True
 
     def get_workflows_by_category(self, category: str) -> list[Workflow]:
         """Get all workflows in a category"""
@@ -287,13 +350,14 @@ class WorkflowManager:
         """Get list of workflows for display"""
         return [
             {
-                "filename": filename,
+                "filename": wf.filename,
+                "path": key,
                 "name": wf.metadata.name,
                 "category": wf.metadata.category,
                 "description": wf.get_short_description(),
                 "tags": wf.metadata.tags,
             }
-            for filename, wf in self.workflows.items()
+            for key, wf in self.workflows.items()
         ]
 
     def search_workflows(self, query: str) -> list[Workflow]:
@@ -320,27 +384,24 @@ class WorkflowManager:
 
     def delete_workflow(self, filename: str) -> bool:
         """Delete a workflow"""
-        if filename not in self.workflows:
+        key = self._resolve_key(filename)
+        if key is None:
             return False
 
         try:
-            workflow = self.workflows[filename]
+            workflow = self.workflows[key]
 
-            # Find and delete files
-            for json_file in self.workflows_dir.rglob(filename):
-                # Delete workflow file
+            json_file = self.workflows_dir / key
+            if json_file.exists():
                 json_file.unlink()
 
-                # Delete metadata file
-                meta_file = json_file.parent / f"{json_file.stem}_meta.json"
-                if meta_file.exists():
-                    meta_file.unlink()
+            meta_file = json_file.with_name(f"{json_file.stem}_meta.json")
+            if meta_file.exists():
+                meta_file.unlink()
 
-            # Remove from memory
-            del self.workflows[filename]
+            del self.workflows[key]
 
-            # Clear current if it was deleted
-            if self.current_workflow_name == filename:
+            if self.current_workflow_name == key:
                 self.current_workflow_name = None
 
             logger.info(f"✓ Deleted workflow: {workflow.metadata.name}")
@@ -352,11 +413,12 @@ class WorkflowManager:
 
     def export_workflow(self, filename: str, export_path: str) -> bool:
         """Export a workflow with metadata"""
-        if filename not in self.workflows:
+        key = self._resolve_key(filename)
+        if key is None:
             return False
 
         try:
-            workflow = self.workflows[filename]
+            workflow = self.workflows[key]
 
             # Create export package
             export_data = {
@@ -399,18 +461,23 @@ class WorkflowManager:
             # Generate unique filename
             base_name = metadata.name.lower().replace(" ", "_")
             filename = f"{base_name}.json"
+            dest_relative = Path("custom") / filename
             counter = 1
-            while filename in self.workflows:
+            while (
+                dest_relative.as_posix() in self.workflows
+                or (self.workflows_dir / dest_relative).exists()
+            ):
                 filename = f"{base_name}_{counter}.json"
+                dest_relative = Path("custom") / filename
                 counter += 1
 
             # Save to custom folder
-            dest_path = self.workflows_dir / "custom" / filename
+            dest_path = self.workflows_dir / dest_relative
             with open(dest_path, "w") as f:
                 json.dump(workflow_data, f, indent=2)
 
             # Save metadata
-            meta_path = self.workflows_dir / "custom" / f"{Path(filename).stem}_meta.json"
+            meta_path = dest_path.with_name(f"{dest_path.stem}_meta.json")
             with open(meta_path, "w") as f:
                 json.dump(metadata.to_dict(), f, indent=2)
 
@@ -438,5 +505,9 @@ class WorkflowManager:
         return {
             "total": len(self.workflows),
             "categories": categories,
-            "current": self.current_workflow_name,
+            "current": (
+                self.workflows[self.current_workflow_name].filename
+                if self.current_workflow_name and self.current_workflow_name in self.workflows
+                else None
+            ),
         }

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -58,6 +58,7 @@ def test_workflow_manager_loads_workflows(workflows_dir: Path) -> None:
     assert listing == [
         {
             "filename": "sample.json",
+            "path": "text2img/sample.json",
             "name": "Sample Workflow",
             "category": "Text2Image",
             "description": "Workflow loaded for unit testing",

--- a/tests/test_workflow_manager.py
+++ b/tests/test_workflow_manager.py
@@ -37,6 +37,35 @@ def populated_workflows_dir(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@pytest.fixture
+def workflows_with_duplicate_names(tmp_path: Path) -> Path:
+    """Create workflows that share the same filename in different folders."""
+
+    configs = [
+        ("folder_one", "Shared Workflow A", "General"),
+        ("folder_two", "Shared Workflow B", "Custom"),
+    ]
+
+    for folder, name, category in configs:
+        target_dir = tmp_path / folder
+        target_dir.mkdir(parents=True)
+
+        data = {"nodes": [{"id": name}]}
+        workflow_file = target_dir / "shared.json"
+        workflow_file.write_text(json.dumps(data), encoding="utf-8")
+
+        metadata = {
+            "name": name,
+            "description": f"Workflow for {name}",
+            "category": category,
+            "tags": ["duplicate"],
+        }
+        meta_file = target_dir / "shared_meta.json"
+        meta_file.write_text(json.dumps(metadata), encoding="utf-8")
+
+    return tmp_path
+
+
 def test_workflow_manager_lists_categories_and_search(populated_workflows_dir: Path) -> None:
     manager = WorkflowManager(str(populated_workflows_dir))
 
@@ -65,6 +94,32 @@ def test_workflow_manager_delete_removes_files(populated_workflows_dir: Path) ->
     assert not workflow_path.exists()
     assert not metadata_path.exists()
     assert manager.get_workflow_count() == 1
+
+
+def test_workflow_manager_handles_duplicate_filenames(
+    workflows_with_duplicate_names: Path,
+) -> None:
+    manager = WorkflowManager(str(workflows_with_duplicate_names))
+
+    assert manager.get_workflow_count() == 2
+
+    paths = {entry["path"] for entry in manager.get_workflows_list()}
+    assert paths == {"folder_one/shared.json", "folder_two/shared.json"}
+
+    first = manager.get_workflow("folder_one/shared.json")
+    assert first is not None
+    assert first.metadata.name == "Shared Workflow A"
+
+    # Ambiguous lookup by filename should fail
+    assert manager.get_workflow("shared.json") is None
+
+    assert manager.set_current_workflow("folder_two/shared.json") is True
+    assert manager.get_current_workflow() is not None
+    assert manager.get_current_workflow().metadata.name == "Shared Workflow B"
+
+    assert manager.delete_workflow("folder_one/shared.json") is True
+    assert manager.get_workflow_count() == 1
+    assert manager.get_workflow("folder_two/shared.json") is not None
 
 
 def test_generate_image_accepts_text2image_category(


### PR DESCRIPTION
## Summary
- update `WorkflowManager` to index workflows by their relative paths and resolve ambiguous identifiers safely
- ensure workflow operations (selection, deletion, export, import) use the new keys and expose paths in listings
- extend tests to cover duplicate filenames in different folders and updated listing expectations

## Testing
- pytest tests/test_workflow_manager.py tests/test_comprehensive.py


------
https://chatgpt.com/codex/tasks/task_e_68e12d593e948328bd39e60017ff9ef4